### PR TITLE
Clarify CIDv0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ See: https://cid.ipfs.io/#zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA
 ### CIDv0
 
 CIDv0 is a backwards-compatible version, where:
-- the `multibase` is always `base58btc` and implicit (not written)
-- the `multicodec` is always `protobuf-mdag` and implicit (not written)
+- the `multibase` of the string representation is always `base58btc` and implicit (not written)
+- the `multicodec` is always `dag-pb` and implicit (not written)
 - the `cid-version` is always `cidv0` and implicit (not written)
 - the `multihash` is written as is but is always a full (length 32) sha256 hash.
 


### PR DESCRIPTION
Stating that CIDv0 is always base58 encoded isn't fully correct as it might
also be binary encoded. This commit makes that a bit clearer. Thanks @cabo
for pointing this out [1].

Also the multicodec for CIDv0 is now called `dag-pb`.

[1]: https://github.com/core-wg/yang-cbor/issues/13#issuecomment-522970153