### PR TITLE
feat: CIDv2 “fat pointers”

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ See the section: [How does it work?](#how-does-it-work)
 <cidv1> ::= <multibase-prefix><multicodec-cidv1><multicodec-content-type><multihash-content-address>
 ```
 
+### CIDv2 ("Fat Pointers")
+
+CIDv2 offers a way to encode context markers (signalling) into the IPLD link layer.
+
+CIDv2 is used for describing both *data* and the *context* for that data. A specific definition of
+context is not needed, as any context one would wish to signal in the link layer is effectively
+supported.
+
+CIDv2 is, quite literally, two CIDs.
+
+```
+<cidv2> ::= <data-cid><context-cid>
+```
+
+CIDv2 *can* be used in a reverse compatible manor with CIDv1 as a codec, which allows for CIDv2
+links to be encoded as separate hash addressed blocks or inlined into data structures with
+and `identity` multihash as CIDv1. The requirements for different use cases will lead to different
+encodings, and as support CIDv2 becomes more widespread we should expect more "native" use of CIDv2.
+
+For instance, IPFS HTTP Gateways redirect to CID based subdomains which introduced a byte limit on the size
+of the link. In this case, IPFS HTTP Gateways would create a single block for the CIDv2 link
+with a 256b multihash encoded into CIDv1 for any redirect subdomain.
+
+
 ## Decoding Algorithm
 
 To decode a CID, follow the following algorithm:


### PR DESCRIPTION
After numerous discussions at IPFS Thing I decided it’s time to pull the trigger on CIDv2.

This isn’t the only PR we’ll need to do, but this should serve as a way to resolve any objections or concerns.

We (DAG House) have a pressing need for these in the short term and will be implementing them rather quickly.

We’ve floated a lot of different solutions to this problem and the one that everyone seems to disagree the least on is the simplest, which is what I’ve proposed: **two cids**.

The first is the data pointer, the second is the context. If you want inline context, use identity multihash.

This also makes CIDv2 a valid CIDv1 codec and can be used for reverse compatibility when necessary (although we should do the work of supporting them natively in the codecs).

Since CIDv2 can be viewed as a tuple of CIDs it’s possible to add support across the existing interfaces representing CIDv2 as a simple list of two CIDs in the existing IPLD Data Model.

There were a lot of discussions about this in-person, so there’s plenty of details I’m sure I’m leaving out, but it’s time to discuss.