### PR TITLE
docs: CID spec should follow IPIP process

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ Yes, kind of! like a file extension, the multicodec identifier establishes the f
 
 We are figuring this out at this time. It will likely be a table of formats for secure distributed systems. So far, we want to address: IPFS's original protobuf format, the new IPLD CBOR format, git, bitcoin, and ethereum objects.
 
+> **Q. What is the process for updating CID specification (e.g., adding a new version)?**
+
+CIDs are a well established standard. IPFS uses CIDs for content-addressing and IPNS.
+Making changes to such key protocol requires a careful review which should include feedback from implementers and stakeholders across ecosystem.
+
+Due to this, changes to CID specification MUST be submitted as an improvement proposal to [ipfs/specs](https://github.com/ipfs/specs/tree/main/IPIP) repository (PR with [IPIP document](https://github.com/ipfs/specs/blob/main/IPIP/0000-template.md)), and follow the IPIP process described there. 
+
+
 ## Maintainers
 
 Captain: [@jbenet](https://github.com/jbenet).


### PR DESCRIPTION
This PR clarifies the CID spec governance by pointing at IPIP process from ipfs/specs repo.

I suggest reusing IPIP because don't have anything better, and _something_ is better than _no process at all_, but other ideas are welcome.


## Rationale

CID specification is extremely important for IPFS ecosystem, and we need a clear policy how spec change proposals (namely, proposing new versions, like https://github.com/multiformats/cid/pull/49) should be handled now and in the future.

We need to have a  policy for CID and other Mutliformats, but since CID is the only one that has the concept of versions, let's scope this to CID repo for now.

### Why IPIP?



The IPIP template provides prompts around key areas that need to be filled, which ensures the bare minimum structure and context that gets everyone up-to-speed, including a summary of relevant prior discussions.

This allows implementers and the wider IPFS community to evaluate, provide more meaningful feedback, and reach a rough consensus around a proposal.