### PR TITLE
js-cid -> js-multiformats

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To decode a CID, follow the following algorithm:
 
 - [go-cid](https://github.com/ipfs/go-cid)
 - [java-cid](https://github.com/ipld/java-cid)
-- [js-cid](https://github.com/multiformats/js-cid)
+- [js-multiformats](https://github.com/multiformats/js-multiformats)
 - [rust-cid](https://github.com/multiformats/rust-cid)
 - [py-cid](https://github.com/ipld/py-cid)
 - [elixir-cid](https://github.com/nocursor/ex-cid)


### PR DESCRIPTION
https://github.com/multiformats/js-cid is deprecated