### PR TITLE
[Editorial] Clarify optionality of multibase prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ Implementers should be careful to detect the presence of this extra byte and rem
 
 In some contexts, CIDs with this extra "NULL" prefix are referred to as "legacy CIDs" to preserve backwards compatibility with earlier data, generated in systems where the NUL prefix was mandatory in all binary handling.
 
+## Variant - CBOR Compatibility
+
 It is also be useful to note that the for compatibility with CBOR systems, CBOR tag `42` was registered to CIDs in the [CBOR IANA registry](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml) binary CIDs.
-Both the legacy form with the NULL prefix and the more commonly-used CIDv1 binary form without it conform to the [tag 42 syntax](https://github.com/ipld/cid-cbor/) expected by CBOR consumers.
+To work with CBOR parsers after a [tag 42 header](https://github.com/ipld/cid-cbor/), ONLY the "legacy form" with NULL prefix can be used. See [the strictness section of the DAG-CBOR spec](https://ipld.io/specs/codecs/dag-cbor/spec/#strictness) for further guidance on CBOR compatibility.
 
 ## Variant - Human-Readable Form
 

--- a/README.md
+++ b/README.md
@@ -170,23 +170,29 @@ Please check their repositories: [multicodec](https://github.com/multiformats/mu
 
 > **Q. Why does CID exist?**
 
-We were using base58btc encoded multihashes in IPFS, and then we needed to switch formats to IPLD. We struggled with lots of problems of addressing data with different formats until we created CIDs. You can read the history of this format here: https://github.com/ipfs/specs/issues/130
+We were using base58btc encoded multihashes in IPFS, and then we needed to switch formats to IPLD. 
+We struggled with lots of problems of addressing data with different formats until we created CIDs. 
+You can read the history of this format here: https://github.com/ipfs/specs/issues/130
 
 > **Q. Is the use of multicodec similar to file extensions?**
 
-Yes, kind of! like a file extension, the multicodec identifier establishes the format of the data. Unlike file extensions, these are in the middle of the identifier and not meant to be changed by users. There is also a short table of supported formats.
+Yes, kind of! like a file extension, the multicodec identifier establishes the format of the data. 
+Unlike file extensions, these are in the middle of the identifier and not meant to be changed by users.
+There is also a short table of supported formats.
 
 > **Q. What formats (multicodec codes) does CID support?**
 
-We are figuring this out at this time. It will likely be a subset of [multicodecs](https://github.com/multiformats/multicodec/blob/master/table.csv) for secure distributed systems. So far, we want to address IPFS's UnixFS and raw blocks ([`dag-pb`](https://ipld.io/specs/codecs/dag-pb/spec/), [`raw`](https://www.iana.org/assignments/media-types/application/vnd.ipld.raw)), IPNS's [`libp2p-key`](https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md), and IPLD's [`dag-json`](https://ipld.io/specs/codecs/dag-json/spec/)/[`dag-cbor`](https://ipld.io/specs/codecs/dag-cbor/spec/) formats.
+We are figuring this out at this time. 
+It will likely be a subset of [multicodecs](https://github.com/multiformats/multicodec/blob/master/table.csv) for secure distributed systems. 
+So far, we want to address IPFS's UnixFS and raw blocks ([`dag-pb`](https://ipld.io/specs/codecs/dag-pb/spec/), [`raw`](https://www.iana.org/assignments/media-types/application/vnd.ipld.raw)), IPNS's [`libp2p-key`](https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md), and IPLD's [`dag-json`](https://ipld.io/specs/codecs/dag-json/spec/)/[`dag-cbor`](https://ipld.io/specs/codecs/dag-cbor/spec/) formats.
 
 > **Q. What is the process for updating CID specification (e.g., adding a new version)?**
 
-CIDs are a well established standard. IPFS uses CIDs for content-addressing and IPNS.
+CIDs are a well established standard. 
+IPFS uses CIDs for content-addressing and IPNS.
 Making changes to such key protocol requires a careful review which should include feedback from implementers and stakeholders across ecosystem.
 
 Due to this, changes to CID specification MUST be submitted as an improvement proposal to [ipfs/specs](https://github.com/ipfs/specs/tree/main/IPIP) repository (PR with [IPIP document](https://github.com/ipfs/specs/blob/main/IPIP/0000-template.md)), and follow the IPIP process described there. 
-
 
 ## Maintainers
 
@@ -196,10 +202,12 @@ Captain: [@jbenet](https://github.com/jbenet).
 
 Contributions welcome. Please check out [the issues](https://github.com/ipld/cid/issues).
 
-Check out our [contributing document](https://github.com/ipld/ipld/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to IPLD are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+Check out our [contributing document](https://github.com/ipld/ipld/blob/master/contributing.md) for more information on how we work, and about contributing in general.
+Please be aware that all interactions related to IPLD are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
 Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 
 ## License
 
-This repository is only for documents. These are licensed under a [CC-BY 3.0 Unported](LICENSE) License © 2016 Protocol Labs Inc.
+This repository is only for documents.
+These are licensed under a [CC-BY 3.0 Unported](LICENSE) License © 2016 Protocol Labs Inc.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Where such binary-only systems interface with mixed systems, such as exposing in
 
 ## Variant Representation - Human Readable CID
 
-It is often advantageous to have a human readable description of a CID, such as for  debugging purposes, unit tests, and documentation. We can easily transform a CID to a "Human Readable CID" by segmenting its constituent parts as follows:
+It is often advantageous to have a human readable description of a CID, such as for  debugging purposes, unit tests, and documentation. We can easily transform a CID to a "Human Readable CID" by translating and segmenting its constituent parts as follows:
 
 ```text
 <hr-cid> ::= <hr-mbc> "-" <hr-cid-mc> "-" <hr-mc> "-" <hr-mh>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Concretely, it's a *typed* content address: a tuple of `(content-type, content-a
 
 Current version: CIDv1
 
-The atomic CIDv1 is a **binary** format composed from `unsigned_varint`s that encode values from the , each of which :
+CIDv1 is a **binary** format composed of [unsigned varints](https://github.com/multiformats/unsigned-varint) prefixing a hash digest to form a self-describing "content address":
 
 ```text
 <cidv1> ::= <CIDv1-multicodec><content-multicodec><multihash>

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ CIDs design takes into account many difficult tradeoffs encountered while buildi
 The multibase prefix minimizes risk of data being base-encoded for transport or interoperability purposes and then being divorced from its context, rendering its base-encoding difficult to detect and reconstruct.
 Furthermore, many transports and export formats require binary to be encoded as text according to one or more base-encodings.
 For this reason, the multibase "prefix" should ONLY be omitted in binary-only contexts, where base-encoding won't be required and context drift is not a concern.
-In such binary-only contexts (like the binary CIDs used as links in a binary data structure like [DAG-CBOR](https://ipld.io/specs/codecs/dag-cbor/spec/#links)), CIDs can be stored and used as "internal CIDs" (internal to a binary system).
+
+In these binary-only contexts, such as the binary CIDs used as links in the binary data structure [DAG-CBOR](https://ipld.io/specs/codecs/dag-cbor/spec/#links)), CIDs can be stored and consumed as "internal CIDs," i.e. internal to a binary system.
 Where such binary-only systems interface with mixed systems, such as exposing internal CIDs to HTTP-based gateways or sending them over text-based transports, an appropriate base-encoding should be chosen and the prefix attached to make them full CIDs, warmly dressed and ready for the outside world.
 
 ## Variant Representation - Human Readable CID

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 ## Table of Contents
 
-- [CID (Content IDentifier) Specification](#cid-content-identifier-specification)
-  - [Table of Contents](#table-of-contents)
   - [Motivation](#motivation)
   - [What is it?](#what-is-it)
   - [How does it work?](#how-does-it-work)

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See: https://cid.ipfs.io/#zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA
 
 ## Design Considerations
 
-CIDs design takes into account many difficult tradeoffs encountered while building [IPFS](https://ipfs.io). These are mostly coming from the multiformats project.
+CIDs design takes into account many difficult tradeoffs encountered while building [IPFS](https://ipfs.tech). These are mostly coming from the multiformats project.
 
 - Compactness: CIDs are binary in nature to ensure these are as compact as possible, as they're meant to be part of longer path identifiers or URIs.
 - Transport friendliness (or "copy-pastability"): CIDs are encoded with multibase to allow choosing the best base for transporting. For example, CIDs can be encoded into base58btc to yield shorter and easily-copy-pastable hashes.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@
 
 ## Motivation
 
-[**CID**](https://github.com/ipld/cid) is a format for referencing content in distributed information systems, like [IPFS](https://ipfs.io). It leverages [content addressing](https://en.wikipedia.org/wiki/Content-addressable_storage), [cryptographic hashing](https://simple.wikipedia.org/wiki/Cryptographic_hash_function), and [self-describing formats](https://github.com/multiformats/multiformats). It is the core identifier used by [IPFS](https://ipfs.io) and [IPLD](https://ipld.io). It uses a [multicodec](https://github.com/multiformats/multicodec) to indicate its version, making it fully self describing.
+[**CID**](https://github.com/ipld/cid) is a format for referencing content in distributed information systems, like [IPFS](https://ipfs.io). 
+It leverages [content addressing](https://en.wikipedia.org/wiki/Content-addressable_storage), [cryptographic hashing](https://simple.wikipedia.org/wiki/Cryptographic_hash_function), and [self-describing formats](https://github.com/multiformats/multiformats). 
+It is the core identifier used by [IPFS](https://ipfs.io) and [IPLD](https://ipld.io). 
+It uses a [multicodec](https://github.com/multiformats/multicodec) to indicate its version, making it fully self describing.
 
 **You can read an in-depth discussion on why this format was needed in IPFS here: https://github.com/ipfs/specs/issues/130 (first post reproduced [here](./original-rfc.md))**
 
 ## What is it?
 
-A CID is a self-describing content-addressed identifier. It uses cryptographic hashes to achieve content addressing. It uses several [multiformats](https://github.com/multiformats/multiformats) to achieve flexible self-description, namely:
+A CID is a self-describing content-addressed identifier. 
+It uses cryptographic hashes to achieve content addressing. It uses several [multiformats](https://github.com/multiformats/multiformats) to achieve flexible self-description, namely:
 1. [multihash](https://github.com/multiformats/multihash) to hash content addressed, and
 2. [multicodec](https://github.com/multiformats/multicodec) to type that addressed content,
 to form a binary self-contained identifier, and optionally also


### PR DESCRIPTION
In the spirit of making all "the specs"...
* ...more explicit
* ...more precise, and 
* ...assume less familarity with the rest of IPFS/PLN styles,

I tried to explain better why CIDs without multibase prefixes will appear in the wild (such as in DAG-CBOR as links).  

While I was there I rephrased a few other things too.